### PR TITLE
Remove support for varnish plugin on trusty ci check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,6 @@ ENV SUPPORTED_PLUGIN_LIST="\
   uptime \
   users \
   uuid \
-  varnish \
   virt \
   vmem \
   vserver \


### PR DESCRIPTION
Remove varnish plugin on trusty from SUPPORTED_PLUGIN_LIST, because colectd 5.11 has dropped support for varnish 3 with https://github.com/collectd/collectd/pull/3360
latest varnish version in trusty is 3.0.5 (https://launchpad.net/ubuntu/trusty/+package/varnish) and there won't be any upgrades of it, as it's not supported anymore (https://wiki.ubuntu.com/Releases)