### PR TITLE
[githubactions] Add a merge job to build and publish containers

### DIFF
--- a/.github/workflows/merge-jobs.yml
+++ b/.github/workflows/merge-jobs.yml
@@ -11,10 +11,21 @@ jobs:
   build_and_publish_container:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Get branch name
         run: |
           export BRANCH="$(${{ github.ref }} | rev | cut -d '/' -f1 | rev )
       - run:
           export SLUG="collectd/ci:${BRANCH}"
-      - run: |
-          echo "Eventually, this will build ${SLUG}, on merge to ${BRANCH}"
+      - name: Build container
+        run:
+          docker build --pull -t "${SLUG}" .
+      - run: docker inspect "${SLUG}"
+      - run: docker history "${SLUG}"
+      - run: docker images
+      - name: Log into the container registry
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - run: docker push "${SLUG}"


### PR DESCRIPTION
The job will run when there's a push (i.e. PR merged) to any branch
other than main.
The job will:

* Build the container
* Publish the container image to dockerhub