### PR TITLE
[gha][periodic] Remove other triggers from schedulled jobs

### DIFF
--- a/.github/workflows/daily-jobs.yml
+++ b/.github/workflows/daily-jobs.yml
@@ -1,11 +1,6 @@
 name: Daily container builds
 
 on:
-  # These push/pr options will be removed one they are proven to work (one PR/push ought to do it)
-  pull_request:
-    branches: main
-  push:
-    branches: main
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/weekly-jobs.yml
+++ b/.github/workflows/weekly-jobs.yml
@@ -1,11 +1,6 @@
 name: Weekly container builds
 
 on:
-  # These push/pr options will be removed one they are proven to work (one PR/push ought to do it)
-  pull_request:
-    branches: main
-  push:
-    branches: main
   schedule:
     - cron: '0 0 * * 0'
 


### PR DESCRIPTION
Remove the push and pull_request triggers from periodic jobs
These triggers were there for testing initially.