### PR TITLE
Build Fedora 34 instead of rawhide for now

### DIFF
--- a/.github/workflows/daily-jobs.yml
+++ b/.github/workflows/daily-jobs.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         branch:
           - sid_amd64
-          - fedora_rawhide_x86_64
+          - fedora34_x86_64 
 
     env:
       SLUG: "collectd/ci:${{ matrix.branch }}"


### PR DESCRIPTION
Building rawhide in github actions fails for some strange reason.