### PR TITLE
Update weekly-jobs.yml

### DIFF
--- a/.github/workflows/weekly-jobs.yml
+++ b/.github/workflows/weekly-jobs.yml
@@ -20,12 +20,12 @@ jobs:
       matrix:
         branch:
           # Debian
+            # Debian 11
+          - bullseye_amd64
             # Debian 10
           - buster_amd64
             # Debian 9
           - stretch_amd64
-            # Debian 8
-          - jessie_amd64
           # Ubuntu
             # Ubuntu 16.04
           - xenial_amd64

--- a/.github/workflows/weekly-jobs.yml
+++ b/.github/workflows/weekly-jobs.yml
@@ -24,8 +24,6 @@ jobs:
           - bullseye_amd64
             # Debian 10
           - buster_amd64
-            # Debian 9
-          - stretch_amd64
           # Ubuntu
             # Ubuntu 16.04
           - xenial_amd64


### PR DESCRIPTION
Use Debian 11 (bullseye) and drop Debian 8 (Jessie) and Debian 9 (stretch), which are both out of support.