### PR TITLE
[gha][PR] Update the PR tests to split tests

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -23,6 +23,13 @@ jobs:
           repository: collectd/collectd
           ref: main
           path: ${{ github.workspace }}/collectd
+      - name: Create the test container
+        run: |
+          docker run -itd --name collectd-pr-test -v "${GITHUB_WORKSPACE}/collectd:/collectd" -w /collectd "${SLUG}"
       - name: Make sure collectd builds on the container
         run: |
-          docker run -v "${GITHUB_WORKSPACE}/collectd:/collectd" -w /collectd "${SLUG}" bash -c './build.sh && ./configure && make && make check'
+         docker exec -w /collectd collectd-pr-test bash -c './build.sh && ./configure && make && make check'
+      - name: Run collectd unit tests
+        continue-on-error: true
+        run: |
+          docker exec -w /collectd collectd-pr-test make check

--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -28,7 +28,7 @@ jobs:
           docker run -itd --name collectd-pr-test -v "${GITHUB_WORKSPACE}/collectd:/collectd" -w /collectd "${SLUG}"
       - name: Make sure collectd builds on the container
         run: |
-         docker exec -w /collectd collectd-pr-test bash -c './build.sh && ./configure && make && make check'
+          docker exec -w /collectd collectd-pr-test bash -c './build.sh && ./configure && make'
       - name: Run collectd unit tests
         continue-on-error: true
         run: |


### PR DESCRIPTION
This change splits the build and test stages into separate steps.
The purpose of this is to make it easier to make a step as optional.
This change is being added because some distros don't reliably pass the
unit tests in the gate.

A secondary benifit of this is that the jobs can be easily be extended
later by adding additional steps, instead of adding the commands into a
monolithic super step.
Another benifit of this is better reporting, as it is easier to see what
stage the tests fail on, and allow independant test steps to continue to
run even if previous tests failed.