### PR TITLE
[el8_x86_64] Update to CentOS Stream 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM quay.io/centos/centos:stream8
 
 ADD redhat.sh /redhat.sh
 COPY /checks/*.sh /checks/


### PR DESCRIPTION
CentOS 8 reached EOL on December 31st, 2021 and no longer receives
updates.
The container has been switched to CentOS Stream 8, so we can continue
to receive updates.