### PR TITLE
[gha] Update triggers for on-merge action

### DIFF
--- a/.github/workflows/merge-jobs.yml
+++ b/.github/workflows/merge-jobs.yml
@@ -1,7 +1,8 @@
 name: Merge jobs
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches-ignore:
       - main
         # topic branches (e.g. fix/something)
@@ -10,6 +11,7 @@ on:
 jobs:
   build_and_publish_container:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - uses: actions/checkout@v2
       - name: Get branch name


### PR DESCRIPTION
The on-merge action did not work, when  collectd/ci-docker#55 was merged.
Trigger has been updated, based on the example in [1].

[1] https://github.community/t/trigger-workflow-only-on-pull-request-merge/17359/4