### PR TITLE
[ci][pr-jobs] Add valgrind opts

### DIFF
--- a/.github/workflows/pr-jobs.yml
+++ b/.github/workflows/pr-jobs.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SLUG: "collectd/ci:test"
+      VALGRIND_OPTS: "--errors-for-leak-kinds=definite"
     steps:
       - uses: actions/checkout@v2
       - name: Build container


### PR DESCRIPTION
Add ``--errors-for-leak-kinds=definite`` valgrind opt so
``make check`` doesn't fail on possible memory leaks