### PR TITLE
Debian bookworm: fix path to APT sources list.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ENV EXTRA_PACKAGES="\
   protobuf-c-compiler \
   protobuf-compiler \
   protobuf-compiler-grpc \
-  python-dev \
+  python3-dev \
   riemann-c-client \
 "
 

--- a/debian.sh
+++ b/debian.sh
@@ -23,7 +23,7 @@ COMMON_PACKAGES="\
   valgrind \
 "
 
-sed -i 's/main$/main contrib non-free/' /etc/apt/sources.list
+sed -i 's/main$/main contrib non-free/' /etc/apt/sources.list.d/debian.sources
 
 cat << EOF > /etc/apt/apt.conf.d/50misc-opts
 APT::Install-Recommends "0";


### PR DESCRIPTION
`/etc/apt/sources.list` no longer exists.