### PR TITLE
sid_amd64: re-enable plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV EXTRA_PACKAGES="\
   javahelper \
   libatasmart-dev \
   libcap-dev \
+  libcurl4-gnutls-dev \
   libdbi-dev \
   libdpdk-dev \
   libesmtp-dev \
@@ -59,9 +60,11 @@ ENV EXTRA_PACKAGES="\
   libxen-dev \
   libxml2-dev \
   libyajl-dev \
+  nvidia-cuda-dev \
   perl \
   protobuf-c-compiler \
   protobuf-compiler \
+  python2-dev \
   python3-dev \
   xfslibs-dev \
 "
@@ -90,6 +93,9 @@ ENV SUPPORTED_PLUGIN_LIST="\
   cpufreq \
   cpusleep \
   csv \
+  curl \
+  curl_json \
+  curl_xml \
   dbi \
   df \
   disk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ ENV EXTRA_PACKAGES="\
   perl \
   protobuf-c-compiler \
   protobuf-compiler \
-  python2-dev \
   python3-dev \
   xfslibs-dev \
 "

--- a/debian.sh
+++ b/debian.sh
@@ -23,6 +23,8 @@ COMMON_PACKAGES="\
   valgrind \
 "
 
+sed -i 's/main$/main contrib non-free/' /etc/apt/sources.list
+
 cat << EOF > /etc/apt/apt.conf.d/50misc-opts
 APT::Install-Recommends "0";
 APT::Install-Suggests "0";

--- a/debian.sh
+++ b/debian.sh
@@ -23,7 +23,7 @@ COMMON_PACKAGES="\
   valgrind \
 "
 
-sed -i 's/main$/main contrib non-free/' /etc/apt/sources.list
+sed -i 's/main$/main contrib non-free/' /etc/apt/sources.list.d/debian.sources
 
 cat << EOF > /etc/apt/apt.conf.d/50misc-opts
 APT::Install-Recommends "0";


### PR DESCRIPTION
* Cherry-pick a fix from `bookworm_amd64` that fixes adjusting the APT sources list. This gives us access to non-free packages, which is required for some plugins.
* Install the cURL library again, despite being broken. The CI system is meant to catch these kind of breakages.